### PR TITLE
Added try/catch in rviz plugin to prevent crash

### DIFF
--- a/src/rviz_plugin/ork_object_display.cpp
+++ b/src/rviz_plugin/ork_object_display.cpp
@@ -100,7 +100,16 @@ void OrkObjectDisplay::onInitialize() {
 
     // Check if we already have loaded the mesh
     object_recognition_core::prototypes::ObjectInfo object_info;
-    info_cache_.getInfo(object.type, object_info);
+    try
+    {
+      info_cache_.getInfo(object.type, object_info);
+    }
+    catch(...)
+    {
+      // If getInfo() throws an exception it leaves object_info
+      // empty, so we can continue with a labelled axis, which is
+      // still useful.
+    }
 
     // Make the mesh be a resource
     std::string mesh_resource;


### PR DESCRIPTION
When the rviz plugin received my RecognizedObjects message, it crashed rviz.

I traced the exception back as far as info_cache.cpp:62 where it initializes an object_recognition_core::db::ObjectDbParameters object.

The message I was sending was probably not what it was expecting, but that should still not crash rviz.  So I just added the try/catch you see here, and that makes it work fine for my purposes.
