### PR TITLE
add missing include of scoped_ptr

### DIFF
--- a/src/info_cache/info_cache.cpp
+++ b/src/info_cache/info_cache.cpp
@@ -36,6 +36,8 @@
 #include <sstream>
 #include <stdio.h>
 
+#include <boost/scoped_ptr.hpp>
+
 #include <geometric_shapes/shape_operations.h>
 
 #include <object_recognition_ros/object_info_cache.h>


### PR DESCRIPTION
This becomes necessary with boost 1.57
