### PR TITLE
Docs: fixing broken links and formatting

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -32,7 +32,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.doctest',
               'sphinx.ext.graphviz',
               'sphinx.ext.intersphinx',
-              'sphinx.ext.pngmath',
+              'sphinx.ext.imgmath',
               'sphinx.ext.todo',
               'sphinx.ext.viewcode']
 
@@ -113,7 +113,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with
 # Sphinx are currently 'default' and 'sphinxdoc'.
-html_theme = 'ecto_theme'
+html_theme = 'sphinxdoc'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -5,11 +5,13 @@
 ROS integration
 ###############
 
-This package defines several ROS interfaces for the :ref:`Object Recognition Kitchen <orkcore:index>`. While ``ORK`` is ROS agnostic, several input/output cells are specific ROS and there is also an RViz plugin.
+This package defines several ROS interfaces for the :ref:`Object Recognition
+Kitchen <orkcore:index>`. While ORK does not require ROS to run, several
+input/output cells are specific to ROS.
 
-   * :ref:`ROS messages <msgs>`
-   * :ref:`Service for Object Info <srv>`
-   * :ref:`Actionlib Server <actionlib>`
-   * :ref:`Publishers and Subscribers <pubsub>`
+- :ref:`ROS messages <msgs>`
+- :ref:`Service for Object Info <srv>`
+- :ref:`Actionlib Server <actionlib>`
+- :ref:`Publishers and Subscribers <pubsub>`
 
 There is also an :ref:`RViz plugin <orkrviz:rviz>`

--- a/doc/source/msgs.rst
+++ b/doc/source/msgs.rst
@@ -1,5 +1,7 @@
 .. _msgs:
 
+:orphan:
+
 Messages
 ########
 

--- a/doc/source/server.rst
+++ b/doc/source/server.rst
@@ -5,16 +5,16 @@
 Actionlib Server
 ################
 
-The Actionlib server helps you retrieve the identified objects in the current snapshot.
-It is defined as follows:
+The Actionlib server helps you retrieve the identified objects in the current
+snapshot. It is defined as follows:
 
-.. literalinclude:: ../../../ork_msgs/action/ObjectRecognition.action
+.. literalinclude:: ../../../object_recognition_msgs/action/ObjectRecognition.action
 
 To run it, you just need to start it with:
 
 
 .. code-block:: sh
-   
+
       rosrun object_recognition_ros server -c whatever_config_file.ork
 
 You can also test it using the client:
@@ -37,7 +37,7 @@ For testing, you can even run the server with a test pipeline:
 Service
 #######
 
-There is a service to get object information: just query it and it will retrieve anything
-that is known about the object. Its definition is as follows:
+There is a service to get object information: just query it and it will retrieve
+anything that is known about the object. Its definition is as follows:
 
 .. program-output:: rossrv show -r object_recognition_msgs/GetObjectInformation.srv


### PR DESCRIPTION
These changes fix doc build errors, warnings, and broken links.