### PR TITLE
implementation of CloudSource

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,17 @@
 cmake_minimum_required(VERSION 2.8)
 project(object_recognition_ros)
+find_package(OpenCV REQUIRED)
+find_package(PCL REQUIRED)
 
+# missing ecto_pcl?
 find_package(catkin REQUIRED cmake_modules ecto ecto_ros geometric_shapes geometry_msgs object_recognition_core
-                             object_recognition_msgs pluginlib rosbag roscpp sensor_msgs
+                             object_recognition_msgs pluginlib rosbag roscpp sensor_msgs ecto_image_pipeline  ecto_pcl
+                       opencv_candidate
                              visualization_msgs
 )
 catkin_package(INCLUDE_DIRS include
   LIBRARIES object_information_cache
-  CATKIN_DEPENDS object_recognition_core object_recognition_msgs
+  CATKIN_DEPENDS object_recognition_core object_recognition_msgs ecto_image_pipeline 
 )
 
 #install targets for all things python

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>ecto</build_depend>
   <build_depend>ecto_ros</build_depend>
+  <build_depend>ecto_pcl</build_depend>
   <build_depend>ecto_image_pipeline</build_depend>
   <build_depend>geometric_shapes</build_depend>
   <build_depend>object_recognition_core</build_depend>
@@ -24,6 +25,7 @@
   <run_depend>boost</run_depend>
   <run_depend>ecto</run_depend>
   <run_depend>ecto_ros</run_depend>
+  <run_depend>ecto_pcl</run_depend>
   <run_depend>ecto_image_pipeline</run_depend>
   <run_depend>geometric_shapes</run_depend>
   <run_depend>object_recognition_core</run_depend>

--- a/python/object_recognition_ros/io/source/__init__.py
+++ b/python/object_recognition_ros/io/source/__init__.py
@@ -1,2 +1,3 @@
 from .ros_kinect import RosKinect
 from .bag_reader import BagReader
+from .cloud_source import CloudSource

--- a/python/object_recognition_ros/io/source/cloud_source.py
+++ b/python/object_recognition_ros/io/source/cloud_source.py
@@ -1,0 +1,102 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided
+# with the distribution.
+# * Neither the name of Willow Garage, Inc. nor the names of its
+# contributors may be used to endorse or promote products derivedo
+# from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""
+Module defining several outputs for the object recognition pipeline
+"""
+
+from ecto_image_pipeline.io.source import create_source
+from object_recognition_core.io.source import SourceBase
+from object_recognition_ros import init_ros
+import ecto
+import ecto_pcl_ros
+import ecto_pcl
+import object_recognition_ros
+from object_recognition_ros.ecto_cells.io_ros  import EctoPointCloudOrganizedToMatXYZ
+from ecto_pcl_ros import Message2PointCloud
+
+from ecto_image_pipeline.io.source.camera_base import CameraType
+from ecto import BlackBoxCellInfo as CellInfo, BlackBoxForward as Forward
+import ecto_ros
+import ecto_ros.ecto_sensor_msgs as ecto_sensor_msgs
+
+PointSub = ecto_sensor_msgs.Subscriber_PointCloud2
+CameraInfoSub = ecto_sensor_msgs.Subscriber_CameraInfo
+
+# similar to SourceBase and Similar to OpenNISubscriber
+#
+# OpenNISubscriber in ecto_image_pipeline from BaseSource: connects to topics and forwards them
+# BaseSource (base of OpenNISubscriber) makes the 3d using DepthTo3D but we do not this: DepthTo3D is sent to crop_box emitted as points3d (CropBox in ecto_opencv)
+#
+# We need the converter from PointCloud2 to points and then simply subscribe
+#
+# Conversions in reconstruction: MatToPointCloud XYZ/XYZRGB Organized
+# Conversions in ecto_pcl: Message2PointCloud and PointCloud2Message
+class CloudSource(ecto.BlackBox):
+    CAMERA_TYPE = CameraType.RGBD
+    def __init__(self, *args, **kwargs):
+        init_ros()
+        ecto.BlackBox.__init__(self, *args, **kwargs)
+
+    @staticmethod
+    def declare_cells(_p):
+        qsize = 1
+        cells = ecto.BlackBox.declare_cells(_p)
+        subs = dict(Ccamera_points=PointSub(topic_name='/bogus_topic_image', queue_size=qsize),
+                    Ccamera_info=CameraInfoSub(topic_name='/bogus_topic_image', queue_size=qsize),
+                 )
+        cells.update(subs)
+        cells['Csource'] = ecto_ros.Synchronizer('Synchronizator', subs=subs)
+        cells['Ccamera_info_image'] = CellInfo(ecto_ros.CameraInfo2Cv) 
+        cells['Cmsg2points'] = Message2PointCloud("msg2cloud",format=ecto_pcl.XYZ)
+        cells['Cpoints2mat'] = EctoPointCloudOrganizedToMatXYZ("points2mat")
+        return cells
+
+    @staticmethod
+    def declare_forwards(_p):
+        p = {}
+        p['Ccamera_info'] = [Forward('topic_name', 'camera_info', 'The ROS topic for the RGB camera info.','/kinect2/sd/camera_info')]
+        p['Ccamera_points']  = [Forward('topic_name', 'camera_points', 'The ROS topic for the RGB camera info.','/kinect2/sd/points')]
+        i = {}
+        o = {'Ccamera_info_image': [Forward('K', 'K_image', 'The camera intrinsics matrix of the image camera.')],
+            "Cpoints2mat" : [Forward('points',"points3d", "The output points for OpenCV")] }
+        return (p,i,o)
+    def configure(self, _p, _i, _o):
+        pass
+    def connections(self, p):
+        #ros message converters
+        graph = [
+          self.Csource["Ccamera_info"] >> self.Ccamera_info_image['camera_info'],
+          self.Csource["Ccamera_points"] >> self.Cmsg2points["input"],
+          self.Cmsg2points["output"] >> self.Cpoints2mat["point_cloud"]
+        ]
+
+        return graph

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -4,9 +4,11 @@ find_package(Eigen REQUIRED)
 include_directories(SYSTEM
                     ${EIGEN_INCLUDE_DIRS}
                     ${ecto_ros_INCLUDE_DIRS}
+                    ${ecto_pcl_INCLUDE_DIRS}
                     ${catkin_INCLUDE_DIRS}
                     ${geometry_msgs_INCLUDE_DIRS}
                     ${object_recognition_core_INCLUDE_DIRS}
+                   ${PCL_INCLUDE_DIRS}
 )
 
 ectomodule(io_ros DESTINATION ${PROJECT_NAME}/ecto_cells
@@ -14,6 +16,13 @@ ectomodule(io_ros DESTINATION ${PROJECT_NAME}/ecto_cells
            module.cpp
            MsgAssembler.cpp
            visualization_msgs_MarkerArray.cpp
+		   MatToPointCloud.cpp
+ 		   PointCloudToMat.cpp
 )
 
-link_ecto(io_ros ${catkin_LIBRARIES})
+link_ecto(io_ros ${catkin_LIBRARIES}
+                                            ${OpenCV_LIBRARIES}
+                                            ${PCL_LIBRARIES}
+)
+
+

--- a/src/io/MatToPointCloud.cpp
+++ b/src/io/MatToPointCloud.cpp
@@ -1,0 +1,185 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2009, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <fstream>
+#include <iostream>
+
+#include <boost/foreach.hpp>
+#include <boost/shared_ptr.hpp>
+
+#include <ecto/ecto.hpp>
+
+#include <opencv2/core/core.hpp>
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include "conversions.hpp"
+
+using ecto::tendrils;
+
+namespace object_recognition_core
+{
+  namespace conversion
+  {
+    /** Ecto implementation of a module that takes a point cloud as
+        an input and stacks it in a matrix of floats:
+        - if the point cloud is organized, the return
+          a matrix is width by height with 3 channels (for x, y and z)
+        - if the point cloud is unorganized, the
+          return a matrix is n_point by 1 with 3 channels (for x, y and z)
+     */
+    struct MatToPointCloudXYZ
+    {
+      // Get the original keypoints and point cloud
+      typedef pcl::PointXYZ PointType;
+      typedef pcl::PointCloud<PointType> CloudType;
+      typedef CloudType::ConstPtr CloudOutT;
+
+
+      static void
+      declare_io(const tendrils& params, tendrils& inputs, tendrils& outputs)
+      {
+        inputs.declare(&MatToPointCloudXYZ::points3d, "points",
+                       "The width by height by 3 channels (x, y and z)");
+        outputs.declare(&MatToPointCloudXYZ::cloud_out, "point_cloud",
+                        "The XYZ point cloud");
+      }
+
+      int
+      process(const tendrils& inputs, const tendrils& outputs)
+      {
+        CloudType::Ptr point_cloud(new CloudType);
+        image_pipeline::cvToCloud(*points3d, *point_cloud);
+        *cloud_out = point_cloud;
+        return ecto::OK;
+      }
+      ecto::spore<cv::Mat> points3d;
+      ecto::spore<CloudOutT> cloud_out;
+    };
+    struct MatToPointCloudXYZOrganized
+    {
+      // Get the original keypoints and point cloud
+      typedef pcl::PointXYZ PointType;
+      typedef pcl::PointCloud<PointType> CloudType;
+      typedef CloudType::ConstPtr CloudOutT;
+
+
+      static void
+      declare_io(const tendrils& params, tendrils& inputs, tendrils& outputs)
+      {
+        inputs.declare(&MatToPointCloudXYZOrganized::points3d, "points", "The width by height by 3 channels (x, y and z)");
+        outputs.declare(&MatToPointCloudXYZOrganized::cloud_out, "point_cloud", "The XYZ point cloud");
+      }
+
+      int
+      process(const tendrils& inputs, const tendrils& outputs)
+      {
+        CloudType::Ptr point_cloud(new CloudType);
+       image_pipeline:: cvToCloudOrganized(*points3d, *point_cloud);
+        *cloud_out = point_cloud;
+        return ecto::OK;
+      }
+      ecto::spore<cv::Mat> points3d;
+      ecto::spore<CloudOutT> cloud_out;
+    };
+    struct MatToPointCloudXYZRGB
+    {
+      typedef pcl::PointXYZRGB PointType;
+      // Get the original keypoints and point cloud
+      typedef pcl::PointCloud<PointType> CloudType;
+      typedef CloudType::ConstPtr CloudOutT;
+
+
+      static void
+      declare_io(const tendrils& params, tendrils& inputs, tendrils& outputs)
+      {
+        inputs.declare(&MatToPointCloudXYZRGB::image, "image", "The rgb image.").required(true);
+        inputs.declare(&MatToPointCloudXYZRGB::points3d, "points", "The 3d points.").required(true);
+        inputs.declare(&MatToPointCloudXYZRGB::mask, "mask", "The binary mask for valid points.");
+        outputs.declare(&MatToPointCloudXYZRGB::cloud_out, "point_cloud", "The XYZRGB point cloud");
+      }
+
+      int
+      process(const tendrils& i, const tendrils& o)
+      {
+        //extract the cloud
+        CloudType::Ptr cloud(new CloudType);
+       image_pipeline:: cvToCloudXYZRGB(*points3d, *cloud, *image, *mask, false);
+        *cloud_out = cloud;
+        return ecto::OK;
+      }
+      ecto::spore<cv::Mat> mask, image, points3d;
+      ecto::spore<CloudOutT> cloud_out;
+
+    };
+    struct MatToPointCloudXYZRGBOrganized
+        {
+          // Get the original keypoints and point cloud
+          typedef pcl::PointXYZRGB PointType;
+          typedef pcl::PointCloud<PointType> CloudType;
+          typedef CloudType::ConstPtr CloudOutT;
+
+
+          static void
+          declare_io(const tendrils& params, tendrils& inputs, tendrils& outputs)
+          {
+            inputs.declare(&MatToPointCloudXYZRGBOrganized::points3d, "points", "The width by height by 3 channels (x, y and z)").required(true);
+            inputs.declare(&MatToPointCloudXYZRGBOrganized::image, "image", "The rgb image.").required(true);
+            outputs.declare(&MatToPointCloudXYZRGBOrganized::cloud_out, "point_cloud", "The XYZRGB organized point cloud");
+          }
+
+          int
+          process(const tendrils& inputs, const tendrils& outputs)
+          {
+            CloudType::Ptr point_cloud(new CloudType);
+
+           image_pipeline::cvToCloudRGBOrganized(*points3d, *image, *point_cloud);
+            *cloud_out = point_cloud;
+            return ecto::OK;
+          }
+          ecto::spore<cv::Mat> points3d, image;
+          ecto::spore<CloudOutT> cloud_out;
+        };
+  }
+}
+
+ECTO_CELL(io_ros, object_recognition_core::conversion::MatToPointCloudXYZ, "MatToPointCloudXYZ",
+          "Given a cv::Mat, convert it to pcl::PointCloud<pcl::PointXYZ>.");
+ECTO_CELL(io_ros, object_recognition_core::conversion::MatToPointCloudXYZOrganized, "MatToPointCloudXYZOrganized",
+          "Given a cv::Mat, convert it to an organized pcl::PointCloud<pcl::PointXYZ>.");
+ECTO_CELL(io_ros, object_recognition_core::conversion::MatToPointCloudXYZRGB, "MatToPointCloudXYZRGB",
+          "Given a cv::Mat, convert it to pcl::PointCloud<pcl::PointXYZRGB>.");
+ECTO_CELL(io_ros, object_recognition_core::conversion::MatToPointCloudXYZRGBOrganized, "MatToPointCloudXYZRGBOrganized",
+          "Given a cv::Mat, convert it to an organized pcl::PointCloud<pcl::PointXYZRGB>.");

--- a/src/io/PointCloudToMat.cpp
+++ b/src/io/PointCloudToMat.cpp
@@ -1,0 +1,145 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2009, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <fstream>
+#include <iostream>
+
+#include <boost/foreach.hpp>
+#include <boost/shared_ptr.hpp>
+#include <ecto/ecto.hpp>
+#include <ecto_pcl/ecto_pcl.hpp>
+#include <ecto_pcl/pcl_cell.hpp>
+
+#include <opencv2/core/core.hpp>
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include "conversions.hpp"
+
+using ecto::tendrils;
+
+namespace object_recognition_core
+{
+  namespace conversion
+  {
+    #if 0
+    /** Ecto implementation of a module that takes a point cloud as
+        an input and stacks it in a matrix of floats:
+        - if the point cloud is organized, the return
+          a matrix is width by height with 3 channels (for x, y and z)
+        - if the point cloud is unorganized, the
+          return a matrix is n_point by 1 with 3 channels (for x, y and z)
+     */
+    struct PointCloudToMatXYZ
+    {
+      // Get the original keypoints and point cloud
+      typedef pcl::PointXYZ PointType;
+      typedef pcl::PointCloud<PointType> CloudType;
+      typedef CloudType::ConstPtr CloudOutT;
+
+
+      static void
+      declare_io(const tendrils& params, tendrils& inputs, tendrils& outputs)
+      {
+        outputs.declare(&PointCloudToMatXYZ::points3d_out, "points",
+                       "The width by height by 3 channels (x, y and z)");
+        inputs.declare(&PointCloudToMatXYZ::cloud_in, "point_cloud",
+                        "The XYZ point cloud");
+      }
+
+      int
+      process(const tendrils& inputs, const tendrils& outputs)
+      {
+        CloudType::Ptr point_cloud(new CloudType);
+        cvToCloud(*points3d, *point_cloud);
+        *cloud_out = point_cloud;
+        return ecto::OK;
+      }
+      ecto::spore<cv::Mat> points3d_out;
+      ecto::spore<CloudOutT> cloud_in;
+    };
+    #endif
+    struct PointCloudOrganizedToMatXYZ
+    {
+      // Get the original keypoints and point cloud
+      typedef pcl::PointXYZ PointType;
+      typedef pcl::PointCloud<PointType> CloudType;
+      typedef CloudType::ConstPtr CloudInT;
+
+      static void
+      declare_io(const tendrils& params, tendrils& inputs, tendrils& outputs)
+      {
+        outputs.declare(&PointCloudOrganizedToMatXYZ::points3d_out, "points", "The width by height by 3 channels (x, y and z)");
+        inputs.declare(&PointCloudOrganizedToMatXYZ::cloud_in, "point_cloud", "The XYZ point cloud");
+      }
+
+      int
+      process(const tendrils& inputs, const tendrils& outputs)
+      {
+        image_pipeline::cvFromCloudOrganized(**cloud_in,*points3d_out);
+        return ecto::OK;
+      }
+      ecto::spore<cv::Mat> points3d_out;
+      ecto::spore<CloudInT> cloud_in;
+    };
+
+    struct EctoPointCloudOrganizedToMatXYZ
+    {
+      typedef pcl::PointXYZ PointType;
+      typedef pcl::PointCloud<PointType> CloudType;
+
+      static void
+      declare_io(const tendrils& params, tendrils& inputs, tendrils& outputs)
+      {
+        outputs.declare(&EctoPointCloudOrganizedToMatXYZ::points3d_out, "points", "The width by height by 3 channels (x, y and z)");
+        inputs.declare(&EctoPointCloudOrganizedToMatXYZ::cloud_in, "point_cloud", "The XYZ point cloud");
+      }
+
+      int
+      process(const tendrils& inputs, const tendrils& outputs)
+      {
+        image_pipeline::cvFromCloudOrganized(*(*cloud_in).cast<CloudType>(),*points3d_out);
+        return ecto::OK;
+      }
+      ecto::spore<cv::Mat> points3d_out;
+      ecto::spore<ecto::pcl::PointCloud> cloud_in;
+    };    
+}
+}
+ECTO_CELL(io_ros, object_recognition_core::conversion::PointCloudOrganizedToMatXYZ, "PointCloudOrganizedToMatXYZ", "Given a pcl::PointCloud<pcl::PointXYZ> produces");
+
+ECTO_CELL(io_ros, object_recognition_core::conversion::EctoPointCloudOrganizedToMatXYZ, "EctoPointCloudOrganizedToMatXYZ", "Given a ecto::pcl::PointCloud produces");
+//ECTO_CELL(io_ros, image_pipeline::conversion::PointCloudToMatXYZ, "PointCloudToMatXYZ",
+//        "Given a pcl::PointCloud<pcl::PointXYZ> produces");

--- a/src/io/conversions.hpp
+++ b/src/io/conversions.hpp
@@ -1,0 +1,232 @@
+#pragma once
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/registration/transforms.h>
+#include <opencv2/core/eigen.hpp>
+
+#include <fstream>
+namespace image_pipeline
+{
+namespace impl
+{
+template<typename PointT, typename DepthT>
+inline void
+cvToCloudOrganized(const cv::Mat_<cv::Vec<DepthT, 3> >& points3d, pcl::PointCloud<PointT>& cloud)
+{
+  typedef cv::Vec<DepthT, 3> DepthVec;
+  assert(points3d.channels() == 3);
+
+  int width = points3d.cols, height = points3d.rows;
+
+  cloud.points.resize(width * height);
+  cloud.width = width;
+  cloud.height = height;
+
+  for (int v = 0; v < height; ++v)
+  {
+    const DepthVec* begin = reinterpret_cast<const DepthVec*>(points3d.ptr(v));
+    for (int u = 0; u < width; ++u, ++begin)
+    {
+      PointT& p = cloud(u, v);
+      p.x = (*begin)[0];
+      p.y = (*begin)[1];
+      p.z = (*begin)[2];
+    }
+  }
+}
+
+template<typename PointT, typename DepthT>
+inline void
+cvFromCloudOrganized(const pcl::PointCloud<PointT>& cloud, cv::Mat & points3d)
+{
+
+  cv::Mat_<cv::Vec<DepthT, 3> > q;
+  int width = cloud.width, height = cloud.height;
+  q.create(width,height);
+  typedef cv::Vec<DepthT, 3> DepthVec;
+
+  for (int v = 0; v < height; ++v)
+  {
+    DepthVec* begin = reinterpret_cast< DepthVec*>(q.ptr(v));
+    for (int u = 0; u < width; ++u, ++begin)
+    {
+      const PointT& p = cloud(u, v);
+      (*begin)[0] = p.x;
+      (*begin)[1] = p.y;
+      (*begin)[2] = p.z;
+    }
+  }
+  points3d = q;
+}
+
+template<typename PointT, typename DepthT>
+inline void
+cvToCloudRGBOrganized(const cv::Mat_<cv::Vec<DepthT, 3> >& points3d, const cv::Mat& rgb, pcl::PointCloud<PointT>& cloud)
+{
+  typedef cv::Vec<DepthT, 3> DepthVec;
+  assert(points3d.channels() == 3);
+  assert(rgb.channels() == 3);
+  assert(rgb.depth() == 0);
+
+  assert(points3d.cols == rgb.cols && points3d.rows == rgb.rows);
+
+  int width = points3d.cols, height = points3d.rows;
+
+  cloud.points.resize(width * height);
+  cloud.width = width;
+  cloud.height = height;
+
+  for (int v = 0; v < height; ++v)
+  {
+    const DepthVec* begin = reinterpret_cast<const DepthVec*>(points3d.ptr(v));
+    const cv::Vec3b* begin_rgb = rgb.ptr<cv::Vec3b>(v);
+    for (int u = 0; u < width; ++u, ++begin_rgb, ++begin)
+    {
+      PointT& p = cloud(u, v);
+      p.x = (*begin)[0];
+      p.y = (*begin)[1];
+      p.z = (*begin)[2];
+      // bgr layout
+      p.r = (*begin_rgb)[0];
+      p.g = (*begin_rgb)[1];
+      p.b = (*begin_rgb)[2];
+    }
+  }
+}
+}
+
+  /**
+   * \breif convert an opencv collection of points to a pcl::PoinCloud, your opencv mat should have NAN's for invalid points.
+   * @param points3d opencv matrix of nx1 3 channel points
+   * @param cloud output cloud
+   * @param rgb the rgb, required, will color points
+   * @param mask the mask, required, must be same size as rgb
+   */
+  inline void
+  cvToCloudXYZRGB(const cv::Mat_<cv::Point3f>& points3d, pcl::PointCloud<pcl::PointXYZRGB>& cloud, const cv::Mat& rgb,
+                  const cv::Mat& mask, bool brg = true)
+  {
+    cloud.clear();
+    cv::Mat_<cv::Point3f>::const_iterator point_it = points3d.begin(), point_end = points3d.end();
+    cv::Mat_<cv::Vec3b>::const_iterator rgb_it = rgb.begin<cv::Vec3b>();
+    cv::Mat_<uchar>::const_iterator mask_it;
+    if(!mask.empty())
+      mask_it = mask.begin<uchar>();
+    for (; point_it != point_end; ++point_it, ++rgb_it)
+    {
+      if(!mask.empty())
+      {
+        ++mask_it;
+        if (!*mask_it)
+          continue;
+      }
+
+      cv::Point3f p = *point_it;
+      if (p.x != p.x || p.y != p.y || p.z != p.z) //throw out NANs
+        continue;
+      pcl::PointXYZRGB cp;
+      cp.x = p.x;
+      cp.y = p.y;
+      cp.z = p.z;
+      cp.r = (*rgb_it)[2]; //expecting in BGR format.
+      cp.g = (*rgb_it)[1];
+      cp.b = (*rgb_it)[0];
+      cloud.push_back(cp);
+    }
+  }
+
+  template<typename PointT>
+  inline void
+  cvToCloud(const cv::Mat_<cv::Point3f>& points3d, pcl::PointCloud<PointT>& cloud, const cv::Mat& mask = cv::Mat())
+  {
+    cloud.clear();
+    cv::Mat_<cv::Point3f>::const_iterator point_it = points3d.begin(), point_end = points3d.end();
+    const bool has_mask = !mask.empty();
+    cv::Mat_<uchar>::const_iterator mask_it;
+    if (has_mask)
+      mask_it = mask.begin<uchar>();
+    cloud.reserve(cloud.width*cloud.height);
+    for (; point_it != point_end; ++point_it, (has_mask ? ++mask_it : mask_it))
+    {
+      if (has_mask && !*mask_it)
+        continue;
+      cv::Point3f p = *point_it;
+      if (p.x != p.x || p.y != p.y || p.z != p.z) //throw out NANs
+        continue;
+      PointT cp;
+      cp.x = p.x;
+      cp.y = p.y;
+      cp.z = p.z;
+      cloud.push_back(cp);
+    }
+  }
+
+  template<typename PointT>
+  inline void
+  cvFromCloudOrganized(const pcl::PointCloud<PointT>& cloud, cv::Mat& points3d)
+  {
+    impl::cvFromCloudOrganized<PointT, float>(cloud,points3d);
+  }
+
+  template<typename PointT>
+  inline void
+  cvToCloudOrganized(const cv::Mat& points3d, pcl::PointCloud<PointT>& cloud)
+  {
+    assert(points3d.channels() == 3);
+    assert(points3d.depth() == 5 || points3d.depth() == 6);
+
+    if (points3d.depth() == 5)
+      impl::cvToCloudOrganized<PointT, float>(points3d, cloud);
+    else
+      impl::cvToCloudOrganized<PointT, double>(points3d, cloud);
+  }
+
+  template<typename PointT>
+  inline void
+  cvToCloudRGBOrganized(const cv::Mat& points3d, const cv::Mat& rgb, pcl::PointCloud<PointT>& cloud)
+  {
+    assert(points3d.channels() == 3);
+    assert(rgb.channels() == 3);
+    assert(rgb.depth() == 0);
+
+    assert(points3d.cols == rgb.cols && points3d.rows == rgb.rows);
+
+    assert(points3d.depth() == 5 || points3d.depth() == 6);
+
+    if (points3d.depth() == 5)
+      impl::cvToCloudRGBOrganized<PointT, float>(points3d, rgb, cloud);
+    else
+      impl::cvToCloudRGBOrganized<PointT, double>(points3d, rgb, cloud);
+  }
+
+      /**
+       * p = R*x + T
+       * if inverse:
+       *  x = R^1*(p - T)
+       */
+  inline Eigen::Affine3f
+  RT2Transform(cv::Mat& R, cv::Mat& T, bool inverse)
+  {
+    //convert the tranform from our fiducial markers to
+    //the Eigen
+    Eigen::Matrix<float, 3, 3> eR;
+    Eigen::Vector3f eT;
+    cv::cv2eigen(R, eR);
+    cv::cv2eigen(T, eT);
+    // p = R*x + T
+    Eigen::Affine3f transform;
+    if (inverse)
+    {
+      //x = R^1*(p - T)
+      transform = Eigen::Translation3f(-eT);
+      transform.prerotate(eR.transpose());
+    }
+    else
+    {
+      //p = R*x + T
+      transform = Eigen::AngleAxisf(eR);
+      transform.translate(eT);
+    }
+    return transform;
+  }
+}


### PR DESCRIPTION

Adding CloudSource for supporting point clouds e.g. using iai_kinect2. This is useful when the point cloud is needed also for other uses, or when the cloud producer applies different reconstruction strategies (e.g. iai_kinect2 distortion of depth)